### PR TITLE
v0.2.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,3 +447,42 @@ If using YAML file, you can use [js-yaml](https://github.com/nodeca/js-yaml) and
           js-yaml usage.yaml > usage.json
 ```
 </details>
+
+##### Output Control and Customization (v0.2.5+)
+
+The governance actions support optional inputs to control how results are reported:
+
+- **`comments-off`**: Set to `"true"` to suppress PR comments. When disabled, comment content will be saved as a workflow artifact for download.
+- **`checkruns-off`**: Set to `"true"` to suppress GitHub status checks. When disabled, check run payload will be saved as a workflow artifact for download.
+- **`checkrun-name`**: Provide a custom name for GitHub check runs. If not specified, the default format is `{Existing CheckRun Name} - {Deployment Name}`, making it easier to identify and track different deployments.
+
+These options provide flexibility for teams that prefer alternative reporting methods or need to manage multiple deployments with clear identification.
+
+> **Note**: When `comments-off` or `checkruns-off` is enabled, the corresponding output will be saved as a workflow artifact accessible from the workflow run page in GitHub Actions.
+
+<details><summary><code>Example: Using output control options</code></summary>
+
+``` yaml
+      - name: Run Cloudability Cost Estimation
+        uses: ibm/ibm-cloudability-governance/actions/cost-estimation@v0.2.x
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          cloudability-host: ${{ secrets.CLOUDABILITY_HOST }}
+          fd-env-id: ${{ secrets.FD_ENV_ID }}
+          deployment-name: "demo"
+          # Optional: Customize output behavior (v0.2.5+)
+          comments-off: "true"
+          checkruns-off: "false"
+          checkrun-name: "Cost Analysis - Demo Deployment"
+          provider-accounts: |
+            {
+              "*": {
+                "account_id": "${{ secrets.AWS_ACCOUNT_ID }}",
+                "vendor": "aws"
+              }
+            }
+          tf-plan: "tfplan.json"
+          resource-usage: "usage.json"
+```
+</details>

--- a/actions/cost-estimation/action.yml
+++ b/actions/cost-estimation/action.yml
@@ -7,6 +7,15 @@ inputs:
   pr-number:
     description: 'Pull Request Number'
     required: true
+  comments-off:
+    description: 'Disable PR comments'
+    required: false
+  checkruns-off:
+    description: 'Disable check runs'
+    required: false
+  checkrun-name:
+    description: 'Custom name for the check run'
+    required: false
   cloudability-host:
     description: 'Cloudability Host URL for fetching governance metadata'
     required: true
@@ -41,6 +50,9 @@ runs:
         STEP_NAME: "cost-estimation"
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_COMMENTS_OFF: ${{ inputs.comments-off }}
+        INPUT_CHECKRUNS_OFF: ${{ inputs.checkruns-off }}
+        INPUT_CHECKRUN_NAME: ${{ inputs.checkrun-name }}
         INPUT_CLOUDABILITY_HOST: ${{ inputs.cloudability-host }}
         INPUT_FD_ENV_ID: ${{ inputs.fd-env-id }}
         INPUT_DEPLOYMENT_NAME: ${{ inputs.deployment-name }}
@@ -49,5 +61,5 @@ runs:
         INPUT_TF_PLAN: ${{ inputs.tf-plan }}
         INPUT_RESOURCE_USAGE: ${{ inputs.resource-usage }}
         ACTION_REPO: ${{ github.action_repository }}
-        ACTION_VERSION: "v0.2.4"
+        ACTION_VERSION: "v0.2.5"
         GH_TOKEN: ${{ inputs.github-token || github.token }}

--- a/actions/frontdoor/login/action.yml
+++ b/actions/frontdoor/login/action.yml
@@ -25,7 +25,7 @@ runs:
       env:
         STEP_NAME: "frontdoor-login"
         ACTION_REPO: ${{ github.action_repository }}
-        ACTION_VERSION: "v0.2.4"
+        ACTION_VERSION: "v0.2.5"
         GH_TOKEN: ${{ inputs.github-token || github.token }}
         INPUT_FD_URL: ${{ inputs.fd-url }}
         INPUT_FD_PUBLIC_KEY: ${{ inputs.fd-public-key }}

--- a/actions/github-info/action.yml
+++ b/actions/github-info/action.yml
@@ -21,5 +21,5 @@ runs:
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
         ACTION_REPO: ${{ github.action_repository }}
-        ACTION_VERSION: "v0.2.4"
+        ACTION_VERSION: "v0.2.5"
         GH_TOKEN: ${{ inputs.github-token || github.token }}

--- a/actions/metadata/action.yml
+++ b/actions/metadata/action.yml
@@ -24,5 +24,5 @@ runs:
         INPUT_CLOUDABILITY_HOST: ${{ inputs.cloudability-host }}
         INPUT_FD_ENV_ID: ${{ inputs.fd-env-id }}
         ACTION_REPO: ${{ github.action_repository }}
-        ACTION_VERSION: "v0.2.4"
+        ACTION_VERSION: "v0.2.5"
         GH_TOKEN: ${{ inputs.github-token || github.token }}

--- a/actions/policy-evaluation/action.yml
+++ b/actions/policy-evaluation/action.yml
@@ -7,6 +7,15 @@ inputs:
   pr-number:
     description: 'Pull Request Number'
     required: true
+  comments-off:
+    description: 'Disable PR comments'
+    required: false
+  checkruns-off:
+    description: 'Disable check runs'
+    required: false
+  checkrun-name:
+    description: 'Custom name for the check run'
+    required: false
   cloudability-host:
     description: 'Cloudability Host URL for fetching governance metadata'
     required: true
@@ -43,6 +52,9 @@ runs:
         STEP_NAME: "policy-evaluation"
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_COMMENTS_OFF: ${{ inputs.comments-off }}
+        INPUT_CHECKRUNS_OFF: ${{ inputs.checkruns-off }}
+        INPUT_CHECKRUN_NAME: ${{ inputs.checkrun-name }}
         INPUT_CLOUDABILITY_HOST: ${{ inputs.cloudability-host }}
         INPUT_FD_ENV_ID: ${{ inputs.fd-env-id }}
         INPUT_DEPLOYMENT_NAME: ${{ inputs.deployment-name }}
@@ -51,6 +63,6 @@ runs:
         INPUT_TF_PLAN: ${{ inputs.tf-plan }}
         INPUT_RESOURCE_USAGE: ${{ inputs.resource-usage }}
         ACTION_REPO: ${{ github.action_repository }}
-        ACTION_VERSION: "v0.2.4"
+        ACTION_VERSION: "v0.2.5"
         GH_TOKEN: ${{ inputs.github-token || github.token }}
 

--- a/actions/recommendation/action.yml
+++ b/actions/recommendation/action.yml
@@ -8,6 +8,15 @@ inputs:
   pr-number:
     description: 'Pull Request number'
     required: true
+  comments-off:
+    description: 'Disable PR comments'
+    required: false
+  checkruns-off:
+    description: 'Disable check runs'
+    required: false
+  checkrun-name:
+    description: 'Custom name for the check run'
+    required: false
   cloudability-host:
     description: 'Cloudability Host URL for fetching governanve metadata'
     required: true
@@ -43,6 +52,9 @@ runs:
         STEP_NAME: "recommendation"
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_COMMENTS_OFF: ${{ inputs.comments-off }}
+        INPUT_CHECKRUNS_OFF: ${{ inputs.checkruns-off }}
+        INPUT_CHECKRUN_NAME: ${{ inputs.checkrun-name }}
         INPUT_CLOUDABILITY_HOST: ${{ inputs.cloudability-host }}
         INPUT_FD_ENV_ID: ${{ inputs.fd-env-id }}
         INPUT_DEPLOYMENT_NAME: ${{ inputs.deployment-name }}
@@ -51,5 +63,5 @@ runs:
         INPUT_TF_PLAN: ${{ inputs.tf-plan }}
         INPUT_RESOURCE_USAGE: ${{ inputs.resource-usage }}
         ACTION_REPO: ${{ github.action_repository }}
-        ACTION_VERSION: "v0.2.4"
+        ACTION_VERSION: "v0.2.5"
         GH_TOKEN: ${{ inputs.github-token || github.token }}


### PR DESCRIPTION
- New optional inputs `comments-off` and `checkruns-off` gives flexibility to suppress PR comments and status checks. If suppressed, Comments Content and CheckRun Payload will be saved as a artifact file downloadable in workflow.
- New `checkrun-name` input to set custom names for GitHub check runs. If its not provided, it is `Existing CheckRun Name - Deployment Name`. Making it easier for customer to identify and track different deployments.
